### PR TITLE
Add LightningFaucet to Lightning Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 ## Lightning Network
 
 - [Lightning Labs](https://lightning.engineering/) - A leading development team building Lightning Network tools.
+- [LightningFaucet](https://lightningfaucet.com/) - A Bitcoin Lightning faucet and rewards site with free sats, Lightning withdrawals, and optional sat-denominated games.
 - [LND (Lightning Network Daemon)](https://github.com/lightningnetwork/lnd) - A complete implementation of the Lightning Network protocol.
 - [Eclair](https://acinq.co/) - A Scala-based implementation of the Lightning Network.
 - [Zap Wallet](https://zap.jackmallers.com/) - A Lightning Network wallet for desktop and mobile.


### PR DESCRIPTION
**Relationship disclosure:** I'm a contributor on LightningFaucet.

**Quality evidence (snapshot 2026-05-19):**
- ~6,600 registered users, ~1,500 monthly Lightning depositors
- Operational since 2024 and active daily
- Backend: custodial LND on a dedicated Bitcoin node
- Products: Lightning faucet, LN-settled casino, poker, and prediction markets
- Settlement is Bitcoin/Lightning focused with no fiat rails

**Ownership transparency:** LightningFaucet is operated by a small team. Contact: support@lightningfaucet.com.

**Content structure:** Added one entry in the Lightning Network section. The description matches the existing list's short format and uses the canonical URL only.

This is a new PR after #8 was closed with labels `needs: quality evidence`, `has-not: declared-relationship-with-project`, `content-structure`, and `no-ownership-transparency`; this version addresses those points.
