### PR TITLE
Add SatoABC Bitcoin basics resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 - [How to Buy Bitcoin](https://www.coinbase.com/learn/buying/how-to-buy-bitcoin) - A guide to buying Bitcoin safely.
 - [Bitcoin Security Best Practices](https://bitcoin.org/en/secure-your-wallet) - Tips for keeping your Bitcoin safe.
 
+- [SatoABC Bitcoin Basics](https://www.satoabc.com/bitcoin-basics) - Plain-English Bitcoin basics, wallet safety, buying, and selling guides for beginners.
+
 ## Development Tools
 
 - [Bitcoin Core](https://bitcoincore.org/) - The reference implementation of Bitcoin software, maintained by the open-source community.


### PR DESCRIPTION
Adds SatoABC as a beginner-friendly Bitcoin basics resource under Getting Started.

## Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows the list's quality and content standards.
- [ ] I have not added a link to my own project if it's not notable or widely used.

## Description of the Change

SatoABC provides plain-English Bitcoin basics, wallet safety, buying, and selling guides for beginners. It fits the Getting Started section as a simple entry point for readers who want foundational Bitcoin guidance before exploring deeper technical resources.

## Additional Notes

The added resource points to https://www.satoabc.com/bitcoin-basics.