### PR TITLE
Add Bitcoin Institute (Satoshi Nakamoto primary-source archive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [Bitcoin Whitepaper](https://bitcoin.org/bitcoin.pdf) - The original whitepaper by Satoshi Nakamoto describing Bitcoin as a peer-to-peer electronic cash system.
 - [BitInfoCharts](https://bitinfocharts.com/) - A platform providing various Bitcoin statistics and market data.
 - [Clark Moody Bitcoin Dashboard](https://bitcoin.clarkmoody.com/dashboard/) - A comprehensive dashboard with Bitcoin metrics.
+- [Bitcoin Institute](https://bitcoin-institute.pages.dev) - A bilingual (English/Japanese) archive of Satoshi Nakamoto primary sources, including forum posts, emails, and mailing-list messages linked to their original sources.
 
 ## Getting Started
 


### PR DESCRIPTION
Adds **Bitcoin Institute** to General Resources.

A bilingual (English/Japanese) reference archive of Satoshi Nakamoto's primary sources — forum posts, private emails, and mailing-list messages — each linked back to its original source, alongside biographies of his correspondents and sourced editorial readings. It sits naturally beside the Bitcoin Whitepaper already listed in this section.

- Format `[NAME](LINK) - DESCRIPTION.` ✓
- Single addition, individual pull request ✓
- A substantive curated resource (3,100+ sourced entries), not a promotional link ✓
- Live (returns HTTP 200), not a duplicate ✓
