### PR TITLE
Add BTCDash to General Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page) - A comprehensive wiki with information about Bitcoin.
 - [Bitcoin Whitepaper](https://bitcoin.org/bitcoin.pdf) - The original whitepaper by Satoshi Nakamoto describing Bitcoin as a peer-to-peer electronic cash system.
 - [BitInfoCharts](https://bitinfocharts.com/) - A platform providing various Bitcoin statistics and market data.
+- [BTCDash](https://btcdash.org/) - A free, real-time Bitcoin dashboard with live price, halving countdown, fees, hashrate, sentiment, and on-chain metrics; no signup required.
 - [Clark Moody Bitcoin Dashboard](https://bitcoin.clarkmoody.com/dashboard/) - A comprehensive dashboard with Bitcoin metrics.
 
 ## Getting Started


### PR DESCRIPTION
## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [ ] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

Adds BTCDash (btcdash.org) to General Resources, placed alphabetically between BitInfoCharts and Clark Moody Bitcoin Dashboard. It's a free, real-time Bitcoin dashboard with live price, halving countdown, fee market, hashrate, sentiment and on-chain metrics — no signup, no ads, fully client-side pulling from public APIs (mempool.space, CoinMetrics, exchanges). Similar in spirit to the Clark Moody dashboard already on the list, with broader on-chain coverage.

### Additional Notes (if any)

Full disclosure: I'm the author of BTCDash. Left the last checklist item unticked for that reason — happy to leave the call on notability to the maintainers.